### PR TITLE
Refactored AV capture logic

### DIFF
--- a/Lobe_iOS.xcodeproj/project.pbxproj
+++ b/Lobe_iOS.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		B55A1EC72572C8FD003EE8AD /* StorageProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55A1EC62572C8FD003EE8AD /* StorageProvider.swift */; };
 		B55A1ED32574F368003EE8AD /* CameraView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55A1ED22574F368003EE8AD /* CameraView.swift */; };
 		B55A1ED825760BAC003EE8AD /* PredictionLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55A1ED725760BAC003EE8AD /* PredictionLayer.swift */; };
+		B55D41462599BB48007C9DBF /* CaptureSessionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55D41452599BB48007C9DBF /* CaptureSessionViewModel.swift */; };
 		B56240FD257ED1E200709520 /* OpenScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B56240FC257ED1E200709520 /* OpenScreenViewModel.swift */; };
 		B58A180C254FC4BE00AD32C1 /* ProjectPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58A180B254FC4BE00AD32C1 /* ProjectPicker.swift */; };
 		B5A4C5FF256B7E0E0092DDD8 /* OpenScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A4C5FE256B7E0E0092DDD8 /* OpenScreen.swift */; };
@@ -63,6 +64,7 @@
 		B55A1EC62572C8FD003EE8AD /* StorageProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageProvider.swift; sourceTree = "<group>"; };
 		B55A1ED22574F368003EE8AD /* CameraView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraView.swift; sourceTree = "<group>"; };
 		B55A1ED725760BAC003EE8AD /* PredictionLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PredictionLayer.swift; sourceTree = "<group>"; };
+		B55D41452599BB48007C9DBF /* CaptureSessionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureSessionViewModel.swift; sourceTree = "<group>"; };
 		B56240FC257ED1E200709520 /* OpenScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenScreenViewModel.swift; sourceTree = "<group>"; };
 		B58A180B254FC4BE00AD32C1 /* ProjectPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectPicker.swift; sourceTree = "<group>"; };
 		B5A4C5FE256B7E0E0092DDD8 /* OpenScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenScreen.swift; sourceTree = "<group>"; };
@@ -144,7 +146,7 @@
 			path = LobeTests;
 			sourceTree = "<group>";
 		};
-		B5173D5E257757910065A01F /* Model */ = {
+		B5173D5E257757910065A01F /* Models */ = {
 			isa = PBXGroup;
 			children = (
 				B55A1ED725760BAC003EE8AD /* PredictionLayer.swift */,
@@ -159,6 +161,7 @@
 			children = (
 				B5173D5625774E990065A01F /* PlayViewModel.swift */,
 				B56240FC257ED1E200709520 /* OpenScreenViewModel.swift */,
+				B55D41452599BB48007C9DBF /* CaptureSessionViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -304,6 +307,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B55D41462599BB48007C9DBF /* CaptureSessionViewModel.swift in Sources */,
 				76A9AF54247F138B002086F7 /* LobeModel.mlmodel in Sources */,
 				9B7B03EB2475DBF300D34020 /* AppDelegate.swift in Sources */,
 				B5173D5B25774F400065A01F /* ImagePreview.swift in Sources */,

--- a/Lobe_iOS.xcodeproj/project.pbxproj
+++ b/Lobe_iOS.xcodeproj/project.pbxproj
@@ -24,7 +24,7 @@
 		B55A1EC72572C8FD003EE8AD /* StorageProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55A1EC62572C8FD003EE8AD /* StorageProvider.swift */; };
 		B55A1ED32574F368003EE8AD /* CameraView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55A1ED22574F368003EE8AD /* CameraView.swift */; };
 		B55A1ED825760BAC003EE8AD /* PredictionLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55A1ED725760BAC003EE8AD /* PredictionLayer.swift */; };
-		B55D41462599BB48007C9DBF /* CaptureSessionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55D41452599BB48007C9DBF /* CaptureSessionViewModel.swift */; };
+		B55D41462599BB48007C9DBF /* CaptureSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55D41452599BB48007C9DBF /* CaptureSessionManager.swift */; };
 		B56240FD257ED1E200709520 /* OpenScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B56240FC257ED1E200709520 /* OpenScreenViewModel.swift */; };
 		B58A180C254FC4BE00AD32C1 /* ProjectPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58A180B254FC4BE00AD32C1 /* ProjectPicker.swift */; };
 		B5A4C5FF256B7E0E0092DDD8 /* OpenScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A4C5FE256B7E0E0092DDD8 /* OpenScreen.swift */; };
@@ -64,7 +64,7 @@
 		B55A1EC62572C8FD003EE8AD /* StorageProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageProvider.swift; sourceTree = "<group>"; };
 		B55A1ED22574F368003EE8AD /* CameraView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraView.swift; sourceTree = "<group>"; };
 		B55A1ED725760BAC003EE8AD /* PredictionLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PredictionLayer.swift; sourceTree = "<group>"; };
-		B55D41452599BB48007C9DBF /* CaptureSessionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureSessionViewModel.swift; sourceTree = "<group>"; };
+		B55D41452599BB48007C9DBF /* CaptureSessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureSessionManager.swift; sourceTree = "<group>"; };
 		B56240FC257ED1E200709520 /* OpenScreenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenScreenViewModel.swift; sourceTree = "<group>"; };
 		B58A180B254FC4BE00AD32C1 /* ProjectPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectPicker.swift; sourceTree = "<group>"; };
 		B5A4C5FE256B7E0E0092DDD8 /* OpenScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenScreen.swift; sourceTree = "<group>"; };
@@ -149,6 +149,7 @@
 		B5173D5E257757910065A01F /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				B55D41452599BB48007C9DBF /* CaptureSessionManager.swift */,
 				B55A1ED725760BAC003EE8AD /* PredictionLayer.swift */,
 				B55A1EC62572C8FD003EE8AD /* StorageProvider.swift */,
 				B53C73752533C150007A0231 /* Project.swift */,
@@ -161,7 +162,6 @@
 			children = (
 				B5173D5625774E990065A01F /* PlayViewModel.swift */,
 				B56240FC257ED1E200709520 /* OpenScreenViewModel.swift */,
-				B55D41452599BB48007C9DBF /* CaptureSessionViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -307,7 +307,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B55D41462599BB48007C9DBF /* CaptureSessionViewModel.swift in Sources */,
+				B55D41462599BB48007C9DBF /* CaptureSessionManager.swift in Sources */,
 				76A9AF54247F138B002086F7 /* LobeModel.mlmodel in Sources */,
 				9B7B03EB2475DBF300D34020 /* AppDelegate.swift in Sources */,
 				B5173D5B25774F400065A01F /* ImagePreview.swift in Sources */,

--- a/Lobe_iOS/Models/CaptureSessionManager.swift
+++ b/Lobe_iOS/Models/CaptureSessionManager.swift
@@ -13,15 +13,14 @@ import VideoToolbox
 
 /// View model for camera view.
 class CaptureSessionManager: NSObject {
-    @Published var captureDevice: AVCaptureDevice?
-    @Published var isEnabled = false
     @Published var previewLayer: AVCaptureVideoPreviewLayer?
     @Published var capturedImageOutput: UIImage?
     let predictionLayer: PredictionLayer
     var captureSession: AVCaptureSession?
-    var backCam: AVCaptureDevice?
-    var frontCam: AVCaptureDevice?
-    var dataOutput: AVCaptureVideoDataOutput?
+    private var backCam: AVCaptureDevice?
+    private var frontCam: AVCaptureDevice?
+    private var dataOutput: AVCaptureVideoDataOutput?
+    private var captureDevice: AVCaptureDevice?
     private var disposables = Set<AnyCancellable>()
     private var totalFrameCount = 0
     
@@ -63,6 +62,13 @@ class CaptureSessionManager: NSObject {
         self.dataOutput = dataOutput
     }
     
+    /// On disable, stop running capture session and then tear down.
+    /// Both steps are required to prroperly shut down camera session.
+    func tearDown() {
+        self.captureSession?.stopRunning()
+        self.captureSession = nil
+    }
+    
     /// Creates a capture session given input device as param.
     private func createCaptureSession(for captureDevice: AVCaptureDevice) -> AVCaptureSession {
         let captureSession = AVCaptureSession()
@@ -87,6 +93,7 @@ class CaptureSessionManager: NSObject {
     /// Toggles between front and back cam.
     func rotateCamera() {
         self.captureDevice = (captureDevice == backCam) ? frontCam : backCam
+        self.resetCameraFeed()
     }
     
     /// Wrapper for screen shot.

--- a/Lobe_iOS/Models/CaptureSessionManager.swift
+++ b/Lobe_iOS/Models/CaptureSessionManager.swift
@@ -11,7 +11,7 @@ import Combine
 import SwiftUI
 
 /// View model for camera view.
-class CaptureSessionViewModel: ObservableObject {
+class CaptureSessionManager: NSObject {
     @Published var captureDevice: AVCaptureDevice?
     @Published var isEnabled = false
     @Published var previewLayer: AVCaptureVideoPreviewLayer?
@@ -29,31 +29,6 @@ class CaptureSessionViewModel: ObservableObject {
         self.backCam = AVCaptureDevice.DiscoverySession(deviceTypes: [.builtInWideAngleCamera], mediaType: AVMediaType.video, position: .back).devices.first
         self.frontCam = AVCaptureDevice.DiscoverySession(deviceTypes: [.builtInWideAngleCamera], mediaType: AVMediaType.video, position: .front).devices.first
         self.captureDevice = backCam
-        
-        /// Reset camera feed if capture device changes.
-        $captureDevice
-            .receive(on: DispatchQueue.main)
-            .sink(receiveValue: { [weak self] _ in
-                guard let isEnabled = self?.isEnabled else  {
-                    return
-                }
-                if isEnabled { self?.resetCameraFeed() }
-            })
-            .store(in: &disposables)
-        
-        /// Reset camera feed if capture session is enabled, or tear-down if disabled.
-        $isEnabled
-            .receive(on: DispatchQueue.main)
-            .sink(receiveValue: { [weak self] _isEnabled in
-                if _isEnabled { self?.resetCameraFeed() }
-                else {
-                    /// On disable, stop running capture session and then tear down.
-                    /// Both steps are required to prroperly shut down camera session.
-                    self?.captureSession?.stopRunning()
-                    self?.captureSession = nil
-                }
-            })
-            .store(in: &disposables)
     }
     
     /// Resets camera feed, which:

--- a/Lobe_iOS/Models/CaptureSessionManager.swift
+++ b/Lobe_iOS/Models/CaptureSessionManager.swift
@@ -16,7 +16,7 @@ class CaptureSessionManager: NSObject {
     @Published var captureDevice: AVCaptureDevice?
     @Published var isEnabled = false
     @Published var previewLayer: AVCaptureVideoPreviewLayer?
-    @Published var imageForPrediction: UIImage?
+    @Published var capturedImageOutput: UIImage?
     let predictionLayer: PredictionLayer
     var captureSession: AVCaptureSession?
     var backCam: AVCaptureDevice?
@@ -106,7 +106,7 @@ extension CaptureSessionManager: AVCaptureVideoDataOutputSampleBufferDelegate {
             return
         }
         
-        // Determine rotation by radians given device orientation and camera device
+        /// Determine rotation by radians given device orientation and camera device
         var radiansToRotate = CGFloat(0)
         switch videoOrientation {
         case .portrait:
@@ -129,14 +129,13 @@ extension CaptureSessionManager: AVCaptureVideoDataOutputSampleBufferDelegate {
             break
         }
 
-        // Rotate and crop the captured image to be the size of the screen.
+        /// Rotate image and flip over x-axis if using front-facing cam.
         let isUsingFrontCam = self.captureDevice == self.frontCam
-        guard let rotatedImage = image.rotate(radians: radiansToRotate, flipX: isUsingFrontCam),
-              let squaredImage = rotatedImage.squared() else {
+        guard let rotatedImage = image.rotate(radians: radiansToRotate, flipX: isUsingFrontCam) else {
             fatalError("Could not rotate or crop image.")
         }
 
-        self.imageForPrediction = squaredImage
+        self.capturedImageOutput = rotatedImage
     }
 }
 

--- a/Lobe_iOS/Models/CaptureSessionManager.swift
+++ b/Lobe_iOS/Models/CaptureSessionManager.swift
@@ -9,18 +9,21 @@
 import AVKit
 import Combine
 import SwiftUI
+import VideoToolbox
 
 /// View model for camera view.
 class CaptureSessionManager: NSObject {
     @Published var captureDevice: AVCaptureDevice?
     @Published var isEnabled = false
     @Published var previewLayer: AVCaptureVideoPreviewLayer?
+    @Published var imageForPrediction: UIImage?
     let predictionLayer: PredictionLayer
     var captureSession: AVCaptureSession?
     var backCam: AVCaptureDevice?
     var frontCam: AVCaptureDevice?
     var dataOutput: AVCaptureVideoDataOutput?
     private var disposables = Set<AnyCancellable>()
+    private var totalFrameCount = 0
     
     init(predictionLayer: PredictionLayer) {
         self.predictionLayer = predictionLayer
@@ -50,9 +53,8 @@ class CaptureSessionManager: NSObject {
         let previewLayer = self.createPreviewLayer(for: captureSession)
         let dataOutput = AVCaptureVideoDataOutput()
 
-        /// Set delegate of video output buffer to the prediction layer, which handles all inference logic
-        /// from the input buffer.
-        dataOutput.setSampleBufferDelegate(self.predictionLayer, queue: DispatchQueue(label: "videoQueue"))
+        /// Set delegate of video output buffer to self.
+        dataOutput.setSampleBufferDelegate(self, queue: DispatchQueue(label: "videoQueue"))
         captureSession.startRunning()
         captureSession.addOutput(dataOutput)
         
@@ -82,11 +84,116 @@ class CaptureSessionManager: NSObject {
         return previewLayer
     }
     
-    // TO-DO
+    /// Toggles between front and back cam.
     func rotateCamera() {
-//        self.captureSession?.stopRunning()
         self.captureDevice = (captureDevice == backCam) ? frontCam : backCam
+    }
+}
 
-//        self.createCaptureSession(for: self.captureDevice)
+extension CaptureSessionManager: AVCaptureVideoDataOutputSampleBufferDelegate {
+    /// Delegate method for `AVCaptureVideoDataOutputSampleBufferDelegate`: formats image for inference.
+    /// The delegate is set in the capture session view model.
+    func captureOutput(_ output: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer, from connection: AVCaptureConnection) {
+        /// Skip frames to optimize.
+        totalFrameCount += 1
+        if totalFrameCount % 20 != 0{ return }
+        
+        guard let pixelBuffer: CVPixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer),
+              let image = UIImage(pixelBuffer: pixelBuffer),
+                let previewLayer = self.previewLayer,
+                let videoOrientation = previewLayer.connection?.videoOrientation else {
+            print("Failed creating image at captureOutput.")
+            return
+        }
+        
+        // Determine rotation by radians given device orientation and camera device
+        var radiansToRotate = CGFloat(0)
+        switch videoOrientation {
+        case .portrait:
+            radiansToRotate = .pi / 2
+            break
+        case .portraitUpsideDown:
+            radiansToRotate = (3 * .pi) / 2
+            break
+        case .landscapeLeft:
+            if (self.captureDevice == self.backCam) {
+                radiansToRotate = .pi
+            }
+            break
+        case .landscapeRight:
+            if (self.captureDevice == self.frontCam) {
+                radiansToRotate = .pi
+            }
+            break
+        default:
+            break
+        }
+
+        // Rotate and crop the captured image to be the size of the screen.
+        let isUsingFrontCam = self.captureDevice == self.frontCam
+        guard let rotatedImage = image.rotate(radians: radiansToRotate, flipX: isUsingFrontCam),
+              let squaredImage = rotatedImage.squared() else {
+            fatalError("Could not rotate or crop image.")
+        }
+
+        self.imageForPrediction = squaredImage
+    }
+}
+
+/// Helpers for editing images.
+extension UIImage {
+    var isPortrait:  Bool    { size.height > size.width }
+    var isLandscape: Bool    { size.width > size.height }
+    var breadth:     CGFloat { min(size.width, size.height) }
+    var breadthSize: CGSize  { .init(width: breadth, height: breadth) }
+    
+    func squared(isOpaque: Bool = false) -> UIImage? {
+        guard let cgImage = cgImage?
+                .cropping(to: .init(origin: .init(x: isLandscape ? ((size.width-size.height)/2).rounded(.down) : 0,
+                                                  y: isPortrait  ? ((size.height-size.width)/2).rounded(.down) : 0),
+                                    size: breadthSize)) else { return nil }
+        let format = imageRendererFormat
+        format.opaque = isOpaque
+        return UIGraphicsImageRenderer(size: breadthSize, format: format).image { _ in
+            UIImage(cgImage: cgImage, scale: 1, orientation: imageOrientation)
+                .draw(in: .init(origin: .zero, size: breadthSize))
+        }
+    }
+    public convenience init?(pixelBuffer: CVPixelBuffer) {
+        var cgImage: CGImage?
+        VTCreateCGImageFromCVPixelBuffer(pixelBuffer, options: nil, imageOut: &cgImage)
+        
+        guard let myImage = cgImage else {
+            return nil
+        }
+        
+        self.init(cgImage: myImage)
+    }
+    
+    func rotate(radians: CGFloat, flipX: Bool = false) -> UIImage? {
+        var newSize = CGRect(origin: CGPoint.zero, size: self.size).applying(CGAffineTransform(rotationAngle: CGFloat(radians))).size
+        // Trim off the extremely small float value to prevent core graphics from rounding it up
+        newSize.width = floor(newSize.width)
+        newSize.height = floor(newSize.height)
+
+        UIGraphicsBeginImageContextWithOptions(newSize, false, self.scale)
+        let context = UIGraphicsGetCurrentContext()!
+
+        // Move origin to middle
+        context.translateBy(x: newSize.width/2, y: newSize.height/2)
+        
+        // Flip x-axis if specified (used to correct front-facing cam
+        if flipX { context.scaleBy(x: -1, y: 1) }
+
+        // Rotate around middle
+        context.rotate(by: CGFloat(radians))
+
+        // Draw the image at its center
+        self.draw(in: CGRect(x: -self.size.width/2, y: -self.size.height/2, width: self.size.width, height: self.size.height))
+
+        let newImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+
+        return newImage
     }
 }

--- a/Lobe_iOS/Models/CaptureSessionManager.swift
+++ b/Lobe_iOS/Models/CaptureSessionManager.swift
@@ -88,6 +88,38 @@ class CaptureSessionManager: NSObject {
     func rotateCamera() {
         self.captureDevice = (captureDevice == backCam) ? frontCam : backCam
     }
+    
+    /// Wrapper for screen shot.
+    func takeScreenShot(in view: UIView) {
+        guard let camImage = self.capturedImageOutput else {
+            fatalError("Could not call takeScreenShot")
+        }
+        
+        /// Create a `UIImageView` for overlaying the shutter animation over the camera view.
+        /// Remove it from the super view after image is saved to storage.
+        let imageView = UIImageView(image: camImage)
+        screenShotAnimate(in: view, imageView: imageView)
+        UIImageWriteToSavedPhotosAlbum(camImage, nil, nil, nil)
+        imageView.removeFromSuperview()
+    }
+    
+    /// Provides flash animation when screenshot is triggered.
+    private func screenShotAnimate(in view: UIView, imageView: UIImageView) {
+        imageView.contentMode = .scaleAspectFit
+        imageView.frame = view.frame
+
+        let black = UIImage(named: "Black")
+        let blackView = UIImageView(image: black)
+        imageView.contentMode = .scaleAspectFill
+        blackView.frame = view.frame
+        view.addSubview(blackView)
+        blackView.alpha = 1
+
+        /// Shutter animation.
+        UIView.animate(withDuration: 0.3, delay: 0, options: UIView.AnimationOptions.curveLinear, animations: {
+            blackView.alpha = 0
+        }, completion: nil)
+    }
 }
 
 extension CaptureSessionManager: AVCaptureVideoDataOutputSampleBufferDelegate {

--- a/Lobe_iOS/Models/PredictionLayer.swift
+++ b/Lobe_iOS/Models/PredictionLayer.swift
@@ -16,6 +16,7 @@ import VideoToolbox
 /// Backend logic for predicting classifiers for a given image.
 class PredictionLayer: NSObject {
     @Published var classificationResult: VNClassificationObservation?
+    @Published var imageForProcessing: UIImage?
     var model: VNCoreMLModel?
     var totalFrameCount = 0
     
@@ -116,10 +117,9 @@ extension PredictionLayer: AVCaptureVideoDataOutputSampleBufferDelegate {
 //                let squaredImage = rotatedImage.squared() else {
 //            fatalError("Could not rotate or crop image.")
 //        }
-        
-        
-//        self.getPrediction(forImage: rotatedImage)
 
+        self.getPrediction(forImage: image)
+        self.imageForProcessing = image
         // TO-DO: explore if we nee this
         /// Crop the captured image to be the size of the screen.
 //        guard let croppedImage = rotatedImage.crop(height: previewLayer.frame.height, width: previewLayer.frame.width) else {

--- a/Lobe_iOS/Models/PredictionLayer.swift
+++ b/Lobe_iOS/Models/PredictionLayer.swift
@@ -15,6 +15,9 @@ class PredictionLayer: NSObject {
     @Published var classificationResult: VNClassificationObservation?
     var model: VNCoreMLModel?
     
+    /// Used for debugging image output
+    @Published var imageForPrediction: UIImage?
+    
     init(model: VNCoreMLModel?) {
         self.model = model
     }
@@ -22,6 +25,7 @@ class PredictionLayer: NSObject {
     /// Prediction handler which updates `classificationResult` publisher.
     func getPrediction(forImage image: UIImage) {
         let requestHandler = createPredictionRequestHandler(forImage: image)
+        self.imageForPrediction = image
         let request = createModelRequest(
             /// Set classification result to publisher
             onComplete: { [weak self] request in

--- a/Lobe_iOS/Models/PredictionLayer.swift
+++ b/Lobe_iOS/Models/PredictionLayer.swift
@@ -6,19 +6,14 @@
 //  Copyright © 2020 Microsoft. All rights reserved.
 //
 
-import AVKit
 import Combine
-import Foundation
 import SwiftUI
 import Vision
-import VideoToolbox
 
 /// Backend logic for predicting classifiers for a given image.
 class PredictionLayer: NSObject {
     @Published var classificationResult: VNClassificationObservation?
-    @Published var imageForProcessing: UIImage?
     var model: VNCoreMLModel?
-    var totalFrameCount = 0
     
     init(model: VNCoreMLModel?) {
         self.model = model
@@ -46,7 +41,7 @@ class PredictionLayer: NSObject {
     }
     
     /// Creates request handler and formats image for prediciton processing.
-    func createPredictionRequestHandler(forImage image: UIImage) -> VNImageRequestHandler {
+    private func createPredictionRequestHandler(forImage image: UIImage) -> VNImageRequestHandler {
         /* Crop to square images and send to the model. */
         guard let cgImage = image.cgImage else {
             fatalError("Could not create cgImage in captureOutput")
@@ -57,7 +52,7 @@ class PredictionLayer: NSObject {
         return requestHandler
     }
     
-    func createModelRequest(onComplete: @escaping (VNRequest) -> (), onError: @escaping (Error) -> ()) -> VNCoreMLRequest {
+    private func createModelRequest(onComplete: @escaping (VNRequest) -> (), onError: @escaping (Error) -> ()) -> VNCoreMLRequest {
         guard let model = model else {
             fatalError("Model not found in prediction layer")
         }
@@ -70,118 +65,4 @@ class PredictionLayer: NSObject {
         })
         return request
     }    
-}
-
-extension PredictionLayer: AVCaptureVideoDataOutputSampleBufferDelegate {
-    /// Delegate method for `AVCaptureVideoDataOutputSampleBufferDelegate`: formats image for inference.
-    /// The delegate is set in the capture session view model.
-    func captureOutput(_ output: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer, from connection: AVCaptureConnection) {
-        /// Skip frames to optimize.
-        totalFrameCount += 1
-        if totalFrameCount % 20 != 0{ return }
-        
-        guard let pixelBuffer: CVPixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer),
-              let image = UIImage(pixelBuffer: pixelBuffer) else {
-//                let previewLayer = self.parent.viewModel.previewLayer,
-//                let videoOrientation = previewLayer.connection?.videoOrientation else {
-            print("Failed creating image at captureOutput.")
-            return
-        }
-        
-//        // Determine rotation by radians given device orientation and camera device
-//        var radiansToRotate = CGFloat(0)
-//        switch videoOrientation {
-//        case .portrait:
-//            radiansToRotate = .pi / 2
-//            break
-//        case .portraitUpsideDown:
-//            radiansToRotate = (3 * .pi) / 2
-//            break
-//        case .landscapeLeft:
-//            if (self.parent.viewModel.captureDevice == self.parent.viewModel.backCam) {
-//                radiansToRotate = .pi
-//            }
-//            break
-//        case .landscapeRight:
-//            if (self.parent.viewModel.captureDevice == self.parent.viewModel.frontCam) {
-//                radiansToRotate = .pi
-//            }
-//            break
-//        default:
-//            break
-//        }
-//
-//        // Rotate and crop the captured image to be the size of the screen.
-//        let isUsingFrontCam = self.parent.viewModel.captureDevice == self.parent.viewModel.frontCam
-//        guard let rotatedImage = image.rotate(radians: radiansToRotate, flipX: isUsingFrontCam),
-//                let squaredImage = rotatedImage.squared() else {
-//            fatalError("Could not rotate or crop image.")
-//        }
-
-        self.getPrediction(forImage: image)
-        self.imageForProcessing = image
-        // TO-DO: explore if we nee this
-        /// Crop the captured image to be the size of the screen.
-//        guard let croppedImage = rotatedImage.crop(height: previewLayer.frame.height, width: previewLayer.frame.width) else {
-//            fatalError("Could not crop image.")
-//        }
-    }
-}
-
-/// Helpers for editing images.
-extension UIImage {
-    var isPortrait:  Bool    { size.height > size.width }
-    var isLandscape: Bool    { size.width > size.height }
-    var breadth:     CGFloat { min(size.width, size.height) }
-    var breadthSize: CGSize  { .init(width: breadth, height: breadth) }
-    
-    func squared(isOpaque: Bool = false) -> UIImage? {
-        guard let cgImage = cgImage?
-                .cropping(to: .init(origin: .init(x: isLandscape ? ((size.width-size.height)/2).rounded(.down) : 0,
-                                                  y: isPortrait  ? ((size.height-size.width)/2).rounded(.down) : 0),
-                                    size: breadthSize)) else { return nil }
-        let format = imageRendererFormat
-        format.opaque = isOpaque
-        return UIGraphicsImageRenderer(size: breadthSize, format: format).image { _ in
-            UIImage(cgImage: cgImage, scale: 1, orientation: imageOrientation)
-                .draw(in: .init(origin: .zero, size: breadthSize))
-        }
-    }
-    public convenience init?(pixelBuffer: CVPixelBuffer) {
-        var cgImage: CGImage?
-        VTCreateCGImageFromCVPixelBuffer(pixelBuffer, options: nil, imageOut: &cgImage)
-        
-        guard let myImage = cgImage else {
-            return nil
-        }
-        
-        self.init(cgImage: myImage)
-    }
-    
-    func rotate(radians: CGFloat, flipX: Bool = false) -> UIImage? {
-        var newSize = CGRect(origin: CGPoint.zero, size: self.size).applying(CGAffineTransform(rotationAngle: CGFloat(radians))).size
-        // Trim off the extremely small float value to prevent core graphics from rounding it up
-        newSize.width = floor(newSize.width)
-        newSize.height = floor(newSize.height)
-
-        UIGraphicsBeginImageContextWithOptions(newSize, false, self.scale)
-        let context = UIGraphicsGetCurrentContext()!
-
-        // Move origin to middle
-        context.translateBy(x: newSize.width/2, y: newSize.height/2)
-        
-        // Flip x-axis if specified (used to correct front-facing cam
-        if flipX { context.scaleBy(x: -1, y: 1) }
-
-        // Rotate around middle
-        context.rotate(by: CGFloat(radians))
-
-        // Draw the image at its center
-        self.draw(in: CGRect(x: -self.size.width/2, y: -self.size.height/2, width: self.size.width, height: self.size.height))
-
-        let newImage = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
-
-        return newImage
-    }
 }

--- a/Lobe_iOS/Models/PredictionLayer.swift
+++ b/Lobe_iOS/Models/PredictionLayer.swift
@@ -6,28 +6,40 @@
 //  Copyright © 2020 Microsoft. All rights reserved.
 //
 
+import AVKit
 import Combine
 import Foundation
 import SwiftUI
 import Vision
-
-protocol ImageClassificationPredicter {
-    func getPrdiction(forImage image: UIImage,
-                      onComplete: @escaping (VNRequest) -> (),
-                      onError: @escaping (Error) -> ())
-}
+import VideoToolbox
 
 /// Backend logic for predicting classifiers for a given image.
-class PredictionLayer: NSObject, ImageClassificationPredicter {
+class PredictionLayer: NSObject {
+    @Published var classificationResult: VNClassificationObservation?
     var model: VNCoreMLModel?
+    var totalFrameCount = 0
     
     init(model: VNCoreMLModel?) {
         self.model = model
     }
     
-    func getPrdiction(forImage image: UIImage, onComplete: @escaping (VNRequest) -> (), onError: @escaping (Error) -> ()) {
+    /// Prediction handler which updates `classificationResult` publisher.
+    func getPrediction(forImage image: UIImage) {
         let requestHandler = createPredictionRequestHandler(forImage: image)
-        let request = createModelRequest(onComplete: onComplete, onError: onError)
+        let request = createModelRequest(
+            /// Set classification result to publisher
+            onComplete: { [weak self] request in
+                guard let classifications = request.results as? [VNClassificationObservation],
+                      !classifications.isEmpty else {
+                    self?.classificationResult = nil
+                    return
+                }
+                let topClassifications = classifications.prefix(1)
+                self?.classificationResult = topClassifications[0]
+            }, onError: { [weak self] error in
+                print("Error getting predictions: \(error)")
+                self?.classificationResult = nil
+            })
         
         try? requestHandler.perform([request])
     }
@@ -57,4 +69,119 @@ class PredictionLayer: NSObject, ImageClassificationPredicter {
         })
         return request
     }    
+}
+
+extension PredictionLayer: AVCaptureVideoDataOutputSampleBufferDelegate {
+    /// Delegate method for `AVCaptureVideoDataOutputSampleBufferDelegate`: formats image for inference.
+    /// The delegate is set in the capture session view model.
+    func captureOutput(_ output: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer, from connection: AVCaptureConnection) {
+        /// Skip frames to optimize.
+        totalFrameCount += 1
+        if totalFrameCount % 20 != 0{ return }
+        
+        guard let pixelBuffer: CVPixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer),
+              let image = UIImage(pixelBuffer: pixelBuffer) else {
+//                let previewLayer = self.parent.viewModel.previewLayer,
+//                let videoOrientation = previewLayer.connection?.videoOrientation else {
+            print("Failed creating image at captureOutput.")
+            return
+        }
+        
+//        // Determine rotation by radians given device orientation and camera device
+//        var radiansToRotate = CGFloat(0)
+//        switch videoOrientation {
+//        case .portrait:
+//            radiansToRotate = .pi / 2
+//            break
+//        case .portraitUpsideDown:
+//            radiansToRotate = (3 * .pi) / 2
+//            break
+//        case .landscapeLeft:
+//            if (self.parent.viewModel.captureDevice == self.parent.viewModel.backCam) {
+//                radiansToRotate = .pi
+//            }
+//            break
+//        case .landscapeRight:
+//            if (self.parent.viewModel.captureDevice == self.parent.viewModel.frontCam) {
+//                radiansToRotate = .pi
+//            }
+//            break
+//        default:
+//            break
+//        }
+//
+//        // Rotate and crop the captured image to be the size of the screen.
+//        let isUsingFrontCam = self.parent.viewModel.captureDevice == self.parent.viewModel.frontCam
+//        guard let rotatedImage = image.rotate(radians: radiansToRotate, flipX: isUsingFrontCam),
+//                let squaredImage = rotatedImage.squared() else {
+//            fatalError("Could not rotate or crop image.")
+//        }
+        
+        
+//        self.getPrediction(forImage: rotatedImage)
+
+        // TO-DO: explore if we nee this
+        /// Crop the captured image to be the size of the screen.
+//        guard let croppedImage = rotatedImage.crop(height: previewLayer.frame.height, width: previewLayer.frame.width) else {
+//            fatalError("Could not crop image.")
+//        }
+    }
+}
+
+/// Helpers for editing images.
+extension UIImage {
+    var isPortrait:  Bool    { size.height > size.width }
+    var isLandscape: Bool    { size.width > size.height }
+    var breadth:     CGFloat { min(size.width, size.height) }
+    var breadthSize: CGSize  { .init(width: breadth, height: breadth) }
+    
+    func squared(isOpaque: Bool = false) -> UIImage? {
+        guard let cgImage = cgImage?
+                .cropping(to: .init(origin: .init(x: isLandscape ? ((size.width-size.height)/2).rounded(.down) : 0,
+                                                  y: isPortrait  ? ((size.height-size.width)/2).rounded(.down) : 0),
+                                    size: breadthSize)) else { return nil }
+        let format = imageRendererFormat
+        format.opaque = isOpaque
+        return UIGraphicsImageRenderer(size: breadthSize, format: format).image { _ in
+            UIImage(cgImage: cgImage, scale: 1, orientation: imageOrientation)
+                .draw(in: .init(origin: .zero, size: breadthSize))
+        }
+    }
+    public convenience init?(pixelBuffer: CVPixelBuffer) {
+        var cgImage: CGImage?
+        VTCreateCGImageFromCVPixelBuffer(pixelBuffer, options: nil, imageOut: &cgImage)
+        
+        guard let myImage = cgImage else {
+            return nil
+        }
+        
+        self.init(cgImage: myImage)
+    }
+    
+    func rotate(radians: CGFloat, flipX: Bool = false) -> UIImage? {
+        var newSize = CGRect(origin: CGPoint.zero, size: self.size).applying(CGAffineTransform(rotationAngle: CGFloat(radians))).size
+        // Trim off the extremely small float value to prevent core graphics from rounding it up
+        newSize.width = floor(newSize.width)
+        newSize.height = floor(newSize.height)
+
+        UIGraphicsBeginImageContextWithOptions(newSize, false, self.scale)
+        let context = UIGraphicsGetCurrentContext()!
+
+        // Move origin to middle
+        context.translateBy(x: newSize.width/2, y: newSize.height/2)
+        
+        // Flip x-axis if specified (used to correct front-facing cam
+        if flipX { context.scaleBy(x: -1, y: 1) }
+
+        // Rotate around middle
+        context.rotate(by: CGFloat(radians))
+
+        // Draw the image at its center
+        self.draw(in: CGRect(x: -self.size.width/2, y: -self.size.height/2, width: self.size.width, height: self.size.height))
+
+        let newImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+
+        return newImage
+    }
 }

--- a/Lobe_iOS/Models/PredictionLayer.swift
+++ b/Lobe_iOS/Models/PredictionLayer.swift
@@ -25,7 +25,14 @@ class PredictionLayer: NSObject {
     /// Prediction handler which updates `classificationResult` publisher.
     func getPrediction(forImage image: UIImage) {
         let requestHandler = createPredictionRequestHandler(forImage: image)
-        self.imageForPrediction = image
+        
+        /// Add image to publisher if enviornment variable is enabled.
+        /// Used for debugging purposes.
+        if Bool(ProcessInfo.processInfo.environment["SHOW_FORMATTED_IMAGE"] ?? "false") ?? false {
+            self.imageForPrediction = image
+        }
+        
+        /// Create request handler.
         let request = createModelRequest(
             /// Set classification result to publisher
             onComplete: { [weak self] request in

--- a/Lobe_iOS/ViewModels/CaptureSessionViewModel.swift
+++ b/Lobe_iOS/ViewModels/CaptureSessionViewModel.swift
@@ -1,0 +1,82 @@
+//
+//  CaptureSessionViewModel.swift
+//  Lobe_iOS
+//
+//  Created by Elliot Boschwitz on 12/27/20.
+//  Copyright © 2020 Microsoft. All rights reserved.
+//
+
+import AVKit
+import Combine
+import SwiftUI
+
+/// View model for camera view.
+class CaptureSessionViewModel: ObservableObject {
+    @Published var captureSession: AVCaptureSession?
+    @Published var captureDevice: AVCaptureDevice?
+    @Published var isEnabled = false
+    private var backCam: AVCaptureDevice?
+    private var frontCam: AVCaptureDevice?
+    private var disposables = Set<AnyCancellable>()
+    
+    init() {
+        self.backCam = AVCaptureDevice.DiscoverySession(deviceTypes: [.builtInWideAngleCamera], mediaType: AVMediaType.video, position: .back).devices.first
+        self.frontCam = AVCaptureDevice.DiscoverySession(deviceTypes: [.builtInWideAngleCamera], mediaType: AVMediaType.video, position: .front).devices.first
+        
+        self.captureDevice = backCam
+        self.captureSession = AVCaptureSession()
+        
+        $captureDevice
+            .receive(on: DispatchQueue.main)
+            .sink(receiveValue: createCaptureSession(for:))
+            .store(in: &disposables)
+        
+        $isEnabled
+            .receive(on: DispatchQueue.main)
+            .sink(receiveValue: { _isEnabled in
+                if (_isEnabled) {
+                    self.createCaptureSession(for: self.captureDevice)
+                } else {
+                    self.captureSession?.stopRunning()
+                }
+            })
+            .store(in: &disposables)
+    }
+    
+    func createCaptureSession(for captureDevice: AVCaptureDevice?) {
+        guard self.isEnabled else {
+            print("Capture session disabled.")
+            return
+        }
+
+        let captureSession = AVCaptureSession()
+
+        guard let captureDevice = captureDevice
+        else {
+            print("Could not start capture session.")
+            return
+        }
+
+        do {
+            let input = try AVCaptureDeviceInput(device: captureDevice)
+            captureSession.addInput(input)
+        } catch {
+            print("Could not create AVCaptureDeviceInput in viewDidLoad.")
+        }
+        
+        captureSession.startRunning()
+        self.captureSession = captureSession
+        
+        // TO-DO
+//        setPreviewLayer()
+//        setOutput()
+    }
+    
+    // TO-DO
+    func rotateCamera() {
+//        self.captureSession?.stopRunning()
+        self.captureDevice = (captureDevice == backCam) ? frontCam : backCam
+
+//        self.createCaptureSession(for: self.captureDevice)
+    }
+}

--- a/Lobe_iOS/ViewModels/PlayViewModel.swift
+++ b/Lobe_iOS/ViewModels/PlayViewModel.swift
@@ -67,32 +67,8 @@ class PlayViewModel: ObservableObject {
         self.$viewMode
             .receive(on: DispatchQueue.main)
             .sink(receiveValue: { [weak self] _viewMode in
-                self?.captureSessionManager.isEnabled = _viewMode == .Camera
-            })
-            .store(in: &disposables)
-        
-        /// Reset camera feed if capture device changes.
-        self.captureSessionManager.$captureDevice
-            .receive(on: DispatchQueue.main)
-            .sink(receiveValue: { [weak self] _ in
-                guard let isEnabled = self?.captureSessionManager.isEnabled else  {
-                    return
-                }
-                if isEnabled { self?.captureSessionManager.resetCameraFeed() }
-            })
-            .store(in: &disposables)
-        
-        /// Reset camera or tear-down on enabled.
-        self.captureSessionManager.$isEnabled
-            .receive(on: DispatchQueue.main)
-            .sink(receiveValue: { [weak self] _isEnabled in
-                if _isEnabled { self?.captureSessionManager.resetCameraFeed() }
-                else {
-                    /// On disable, stop running capture session and then tear down.
-                    /// Both steps are required to prroperly shut down camera session.
-                    self?.captureSessionManager.captureSession?.stopRunning()
-                    self?.captureSessionManager.captureSession = nil
-                }
+                if _viewMode == .Camera { self?.captureSessionManager.resetCameraFeed() }
+                else { self?.captureSessionManager.tearDown() }
             })
             .store(in: &disposables)
     }

--- a/Lobe_iOS/ViewModels/PlayViewModel.swift
+++ b/Lobe_iOS/ViewModels/PlayViewModel.swift
@@ -12,21 +12,24 @@ import SwiftUI
 enum PlayViewMode {
     case Camera
     case ImagePreview
+    case NotLoaded
 }
 
 /// View model for the Play View
 class PlayViewModel: ObservableObject {
     @Published var classificationLabel: String?
     @Published var confidence: Float?
-    @Published var viewMode: PlayViewMode = PlayViewMode.Camera
+    @Published var viewMode: PlayViewMode = PlayViewMode.NotLoaded
     @Published var showImagePicker: Bool = false
+    var captureSessionManager: CaptureSessionManager
     let project: Project
-    let imagePredicter: PredictionLayer
+    var imagePredicter: PredictionLayer
     private var disposables = Set<AnyCancellable>()
     
     init(project: Project) {
         self.project = project
         self.imagePredicter = PredictionLayer(model: project.model)
+        self.captureSessionManager = CaptureSessionManager(predictionLayer: self.imagePredicter)
         
         /// Subscribe to classifier results from prediction layer
         self.imagePredicter.$classificationResult
@@ -39,6 +42,39 @@ class PlayViewModel: ObservableObject {
                 self?.classificationLabel = _classificationResult.identifier
                 self?.confidence = _classificationResult.confidence
                 
+            })
+            .store(in: &disposables)
+
+        /// Update camera session if toggled between view mode.
+        self.$viewMode
+            .receive(on: DispatchQueue.main)
+            .sink(receiveValue: { [weak self] _viewMode in
+                self?.captureSessionManager.isEnabled = _viewMode == .Camera
+            })
+            .store(in: &disposables)
+        
+        /// Reset camera feed if capture device changes.
+        self.captureSessionManager.$captureDevice
+            .receive(on: DispatchQueue.main)
+            .sink(receiveValue: { [weak self] _ in
+                guard let isEnabled = self?.captureSessionManager.isEnabled else  {
+                    return
+                }
+                if isEnabled { self?.captureSessionManager.resetCameraFeed() }
+            })
+            .store(in: &disposables)
+        
+        /// Reset camera or tear-down on enabled.
+        self.captureSessionManager.$isEnabled
+            .receive(on: DispatchQueue.main)
+            .sink(receiveValue: { [weak self] _isEnabled in
+                if _isEnabled { self?.captureSessionManager.resetCameraFeed() }
+                else {
+                    /// On disable, stop running capture session and then tear down.
+                    /// Both steps are required to prroperly shut down camera session.
+                    self?.captureSessionManager.captureSession?.stopRunning()
+                    self?.captureSessionManager.captureSession = nil
+                }
             })
             .store(in: &disposables)
     }

--- a/Lobe_iOS/Views/PlayView/CameraView.swift
+++ b/Lobe_iOS/Views/PlayView/CameraView.swift
@@ -19,7 +19,9 @@ struct CameraView: UIViewControllerRepresentable {
     }
 
     func makeUIViewController(context: Context) -> CaptureSessionViewController {
-        CaptureSessionViewController()
+        let vc = CaptureSessionViewController()
+        vc.gestureDelegate = context.coordinator
+        return vc
     }
     
     /// Update preview layer when state changes for camera device 
@@ -36,43 +38,19 @@ struct CameraView: UIViewControllerRepresentable {
         Coordinator(self)
     }
     
-    class Coordinator: NSObject {
+    class Coordinator: NSObject, CaptureSessionGestureDelegate {
         var parent: CameraView
         
         init(_ parent: CameraView) {
             self.parent = parent
         }
-
-        /// Wrapper for screen shot.
-        func takeScreenShot(inView view: UIView) {
-            // guard let camImage = self.parent.viewModel.image else {
-            //     fatalError("Could not call takeScreenShot")
-            // }
-
-            // /// Create a `UIImageView` for overlaying the shutter animation over the camera view.
-            // /// Remove it from the super view after image is saved to storage.
-            // let imageView = UIImageView(image: camImage)
-            // screenShotAnimate(inView: view, imageView: imageView)
-            // UIImageWriteToSavedPhotosAlbum(camImage, nil, nil, nil)
-            // imageView.removeFromSuperview()
+        
+        func viewRecognizedDoubleTap() {
+            parent.captureSessionManager.rotateCamera()
         }
         
-        /// Provides flash animation when screenshot is triggered.
-        private func screenShotAnimate(inView view: UIView, imageView: UIImageView) {
-            // imageView.contentMode = .scaleAspectFit
-            // imageView.frame = view.frame
-            
-            // let black = UIImage(named: "Black")
-            // let blackView = UIImageView(image: black)
-            // imageView.contentMode = .scaleAspectFill
-            // blackView.frame = view.frame
-            // view.addSubview(blackView)
-            // blackView.alpha = 1
-            
-            // /* Shutter animation. */
-            // UIView.animate(withDuration: 0.3, delay: 0, options: UIView.AnimationOptions.curveLinear, animations: {
-            //     blackView.alpha = 0
-            // }, completion: nil)
+        func viewRecognizedTripleTap(_ view: UIView) {
+            parent.captureSessionManager.takeScreenShot(in: view)
         }
     }
 }

--- a/Lobe_iOS/Views/PlayView/CameraView.swift
+++ b/Lobe_iOS/Views/PlayView/CameraView.swift
@@ -12,7 +12,11 @@ import UIKit
 import Vision
 
 struct CameraView: UIViewControllerRepresentable {
-    @ObservedObject var viewModel: CaptureSessionViewModel
+    var captureSessionManager: CaptureSessionManager
+    
+    init(captureSessionManager: CaptureSessionManager) {
+        self.captureSessionManager = captureSessionManager
+    }
 
     func makeUIViewController(context: Context) -> CaptureSessionViewController {
         CaptureSessionViewController()
@@ -21,7 +25,7 @@ struct CameraView: UIViewControllerRepresentable {
     /// Update preview layer when state changes for camera device
     func updateUIViewController(_ uiViewController: CaptureSessionViewController, context: Context) {
         /// Set view with previewlayer
-        let previewLayer = self.viewModel.previewLayer
+        let previewLayer = self.captureSessionManager.previewLayer
         uiViewController.previewLayer = previewLayer
         uiViewController.configureVideoOrientation(for: previewLayer)
         if previewLayer != nil { uiViewController.view.layer.addSublayer(previewLayer!) }

--- a/Lobe_iOS/Views/PlayView/CameraView.swift
+++ b/Lobe_iOS/Views/PlayView/CameraView.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2020 Microsoft. All rights reserved.
 //
 
-import Foundation
+import AVKit
 import SwiftUI
 import UIKit
 import Vision
@@ -19,17 +19,27 @@ protocol CameraViewDelegate: class {
     func setCameraImage(with croppedImage: UIImage)
 }
 
-
 struct CameraView: UIViewControllerRepresentable {
-    @ObservedObject var viewModel: PlayViewModel
+    // TO-DO: think about renaming viewmodel here
+    
+
+//    @ObservedObject var viewModel: PlayViewModel
+    @ObservedObject var captureSessionViewModel: CaptureSessionViewModel
 
     func makeUIViewController(context: Context) -> CaptureSessionViewController {
-        let vc = CaptureSessionViewController()
+        let vc = CaptureSessionViewController(viewModel: captureSessionViewModel)
         vc.delegate = context.coordinator
         return vc
     }
     
-    func updateUIViewController(_ uiViewController: CaptureSessionViewController, context: Context) { }
+    func updateUIViewController(_ uiViewController: CaptureSessionViewController, context: Context) {
+        /// Update preview layer when state changes for camera device
+        // TO-DO: need a check here so that this doesn't crash device
+        if self.captureSessionViewModel.captureSession != nil {
+            uiViewController.setPreviewLayer()
+            uiViewController.setOutput()
+        }
+    }
     
     func makeCoordinator() -> Coordinator {
         Coordinator(self)
@@ -43,41 +53,41 @@ struct CameraView: UIViewControllerRepresentable {
         }
         /// Wrapper for screen shot, which saves to storage the image which gets used for inference.
         func takeScreenShot(inView view: UIView) {
-            guard let camImage = self.parent.viewModel.image else {
-                fatalError("Could not call takeScreenShot")
-            }
+            // guard let camImage = self.parent.viewModel.image else {
+            //     fatalError("Could not call takeScreenShot")
+            // }
 
-            /// Create a `UIImageView` for overlaying the shutter animation over the camera view.
-            /// Remove it from the super view after image is saved to storage.
-            let imageView = UIImageView(image: camImage)
-            screenShotAnimate(inView: view, imageView: imageView)
-            UIImageWriteToSavedPhotosAlbum(camImage, nil, nil, nil)
-            imageView.removeFromSuperview()
+            // /// Create a `UIImageView` for overlaying the shutter animation over the camera view.
+            // /// Remove it from the super view after image is saved to storage.
+            // let imageView = UIImageView(image: camImage)
+            // screenShotAnimate(inView: view, imageView: imageView)
+            // UIImageWriteToSavedPhotosAlbum(camImage, nil, nil, nil)
+            // imageView.removeFromSuperview()
         }
         
         /// Provides flash animation when screenshot is triggered.
         private func screenShotAnimate(inView view: UIView, imageView: UIImageView) {
-            imageView.contentMode = .scaleAspectFit
-            imageView.frame = view.frame
+            // imageView.contentMode = .scaleAspectFit
+            // imageView.frame = view.frame
             
-            let black = UIImage(named: "Black")
-            let blackView = UIImageView(image: black)
-            imageView.contentMode = .scaleAspectFill
-            blackView.frame = view.frame
-            view.addSubview(blackView)
-            blackView.alpha = 1
+            // let black = UIImage(named: "Black")
+            // let blackView = UIImageView(image: black)
+            // imageView.contentMode = .scaleAspectFill
+            // blackView.frame = view.frame
+            // view.addSubview(blackView)
+            // blackView.alpha = 1
             
-            /* Shutter animation. */
-            UIView.animate(withDuration: 0.3, delay: 0, options: UIView.AnimationOptions.curveLinear, animations: {
-                blackView.alpha = 0
-            }, completion: nil)
+            // /* Shutter animation. */
+            // UIView.animate(withDuration: 0.3, delay: 0, options: UIView.AnimationOptions.curveLinear, animations: {
+            //     blackView.alpha = 0
+            // }, completion: nil)
         }
         
         /// Sets view model image.
         func setCameraImage(with croppedImage: UIImage) {
-            DispatchQueue.main.async { [weak self] in
-                self?.parent.viewModel.image = croppedImage
-            }
+//            DispatchQueue.main.async { [weak self] in
+//                self?.parent.viewModel.image = croppedImage
+//            }
         }
     }
 }

--- a/Lobe_iOS/Views/PlayView/CameraView.swift
+++ b/Lobe_iOS/Views/PlayView/CameraView.swift
@@ -13,11 +13,9 @@ import Vision
 
 struct CameraView: UIViewControllerRepresentable {
     @ObservedObject var viewModel: CaptureSessionViewModel
-    @Binding var imageForInference: UIImage?
 
     func makeUIViewController(context: Context) -> CaptureSessionViewController {
-        self.viewModel.dataOutput?.setSampleBufferDelegate(context.coordinator, queue: DispatchQueue(label: "videoQueue"))
-        return CaptureSessionViewController()
+        CaptureSessionViewController()
     }
     
     /// Update preview layer when state changes for camera device
@@ -27,68 +25,17 @@ struct CameraView: UIViewControllerRepresentable {
         uiViewController.previewLayer = previewLayer
         uiViewController.configureVideoOrientation(for: previewLayer)
         if previewLayer != nil { uiViewController.view.layer.addSublayer(previewLayer!) }
-        
-        /// Set data output delegate
-        self.viewModel.dataOutput?.setSampleBufferDelegate(context.coordinator, queue: DispatchQueue(label: "videoQueue"))
     }
     
     func makeCoordinator() -> Coordinator {
         Coordinator(self)
     }
     
-    class Coordinator: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate {
+    class Coordinator: NSObject {
         var parent: CameraView
-        var totalFrameCount = 0
         
         init(_ parent: CameraView) {
             self.parent = parent
-        }
-        
-        /// Delegate method for `AVCaptureVideoDataOutputSampleBufferDelegate`: formats image for inference
-        func captureOutput(_ output: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer, from connection: AVCaptureConnection) {
-            /// Skip frames to optimize.
-            totalFrameCount += 1
-            if totalFrameCount % 20 != 0{ return }
-            
-            guard let pixelBuffer: CVPixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer),
-                  let image = UIImage(pixelBuffer: pixelBuffer),
-                  let previewLayer = self.parent.viewModel.previewLayer,
-                  let videoOrientation = previewLayer.connection?.videoOrientation else {
-                print("Failed creating image at captureOutput.")
-                return
-            }
-            
-            // Determine rotation by radians given device orientation and camera device
-            var radiansToRotate = CGFloat(0)
-            switch videoOrientation {
-            case .portrait:
-                radiansToRotate = .pi / 2
-                break
-            case .portraitUpsideDown:
-                radiansToRotate = (3 * .pi) / 2
-                break
-            case .landscapeLeft:
-                if (self.parent.viewModel.captureDevice == self.parent.viewModel.backCam) {
-                    radiansToRotate = .pi
-                }
-                break
-            case .landscapeRight:
-                if (self.parent.viewModel.captureDevice == self.parent.viewModel.frontCam) {
-                    radiansToRotate = .pi
-                }
-                break
-            default:
-                break
-            }
-            
-            // Rotate and crop the captured image to be the size of the screen.
-            let isUsingFrontCam = self.parent.viewModel.captureDevice == self.parent.viewModel.frontCam
-            guard let rotatedImage = image.rotate(radians: radiansToRotate, flipX: isUsingFrontCam),
-                  let squaredImage = rotatedImage.squared() else {
-                fatalError("Could not rotate or crop image.")
-            }
-            
-//            self.setCameraImage(with: squaredImage)
         }
 
         /// Wrapper for screen shot.

--- a/Lobe_iOS/Views/PlayView/CameraView.swift
+++ b/Lobe_iOS/Views/PlayView/CameraView.swift
@@ -22,13 +22,14 @@ struct CameraView: UIViewControllerRepresentable {
         CaptureSessionViewController()
     }
     
-    /// Update preview layer when state changes for camera device
+    /// Update preview layer when state changes for camera device 
     func updateUIViewController(_ uiViewController: CaptureSessionViewController, context: Context) {
         /// Set view with previewlayer
         let previewLayer = self.captureSessionManager.previewLayer
         uiViewController.previewLayer = previewLayer
         uiViewController.configureVideoOrientation(for: previewLayer)
         if previewLayer != nil { uiViewController.view.layer.addSublayer(previewLayer!) }
+        else { print("Preview layer null in updateUIViewController.") }
     }
     
     func makeCoordinator() -> Coordinator {

--- a/Lobe_iOS/Views/PlayView/CaptureSessionViewController.swift
+++ b/Lobe_iOS/Views/PlayView/CaptureSessionViewController.swift
@@ -8,9 +8,10 @@
 
 import AVKit
 import Foundation
-import VideoToolbox
 
-/// View controller for setting camera output to UI view.
+/// View controller for video capture session. It's responsibilities include:
+/// 1. Setting camera output to UI view.
+/// 2. Handling orientation changes.
 class CaptureSessionViewController: UIViewController {
     var previewLayer: AVCaptureVideoPreviewLayer?
     
@@ -59,67 +60,9 @@ class CaptureSessionViewController: UIViewController {
                 preview.frame = self.view.bounds
                 connection.videoOrientation = videoOrientation
             }
+
             preview.frame = self.view.bounds
-            
         }
-    }
-}
-
-/// Helpers for editing images.
-extension UIImage {
-    var isPortrait:  Bool    { size.height > size.width }
-    var isLandscape: Bool    { size.width > size.height }
-    var breadth:     CGFloat { min(size.width, size.height) }
-    var breadthSize: CGSize  { .init(width: breadth, height: breadth) }
-    
-    func squared(isOpaque: Bool = false) -> UIImage? {
-        guard let cgImage = cgImage?
-                .cropping(to: .init(origin: .init(x: isLandscape ? ((size.width-size.height)/2).rounded(.down) : 0,
-                                                  y: isPortrait  ? ((size.height-size.width)/2).rounded(.down) : 0),
-                                    size: breadthSize)) else { return nil }
-        let format = imageRendererFormat
-        format.opaque = isOpaque
-        return UIGraphicsImageRenderer(size: breadthSize, format: format).image { _ in
-            UIImage(cgImage: cgImage, scale: 1, orientation: imageOrientation)
-                .draw(in: .init(origin: .zero, size: breadthSize))
-        }
-    }
-    public convenience init?(pixelBuffer: CVPixelBuffer) {
-        var cgImage: CGImage?
-        VTCreateCGImageFromCVPixelBuffer(pixelBuffer, options: nil, imageOut: &cgImage)
-        
-        guard let myImage = cgImage else {
-            return nil
-        }
-        
-        self.init(cgImage: myImage)
-    }
-    
-    func rotate(radians: CGFloat, flipX: Bool = false) -> UIImage? {
-        var newSize = CGRect(origin: CGPoint.zero, size: self.size).applying(CGAffineTransform(rotationAngle: CGFloat(radians))).size
-        // Trim off the extremely small float value to prevent core graphics from rounding it up
-        newSize.width = floor(newSize.width)
-        newSize.height = floor(newSize.height)
-
-        UIGraphicsBeginImageContextWithOptions(newSize, false, self.scale)
-        let context = UIGraphicsGetCurrentContext()!
-
-        // Move origin to middle
-        context.translateBy(x: newSize.width/2, y: newSize.height/2)
-        
-        // Flip x-axis if specified (used to correct front-facing cam
-        if flipX { context.scaleBy(x: -1, y: 1) }
-
-        // Rotate around middle
-        context.rotate(by: CGFloat(radians))
-
-        // Draw the image at its center
-        self.draw(in: CGRect(x: -self.size.width/2, y: -self.size.height/2, width: self.size.width, height: self.size.height))
-
-        let newImage = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
-
-        return newImage
     }
 }
 

--- a/Lobe_iOS/Views/PlayView/CaptureSessionViewController.swift
+++ b/Lobe_iOS/Views/PlayView/CaptureSessionViewController.swift
@@ -13,21 +13,6 @@ import VideoToolbox
 /// View controller for setting camera output to UI view.
 class CaptureSessionViewController: UIViewController {
     var previewLayer: AVCaptureVideoPreviewLayer?
-
-    var viewModel: CaptureSessionViewModel?
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
-    init(viewModel: CaptureSessionViewModel) {
-        super.init(nibName: nil, bundle: nil)
-        self.viewModel = viewModel
-    }
-    
-    override func viewDidLoad() {
-        super.viewDidLoad()
-    }
     
     /// Set video configuration for subview layout
     override func viewDidLayoutSubviews() {
@@ -49,26 +34,9 @@ class CaptureSessionViewController: UIViewController {
 //        self.captureSession?.stopRunning()
 //        startCaptureSession()
 //    }
-
-    func setPreviewLayer() {
-        // TO-DO: 1. move this to view model
-        // TO-DO: 2. fix the number of calls amde here
-        
-        
-        
-        guard let captureSession = self.viewModel?.captureSession else {
-            fatalError("Preview layer not set.")
-        }
-        let previewLayer = AVCaptureVideoPreviewLayer(session: captureSession)
-        previewLayer.videoGravity = AVLayerVideoGravity.resizeAspectFill
-        configureVideoOrientation(for: previewLayer)
-        view.layer.addSublayer(previewLayer)
-        
-        self.previewLayer = previewLayer
-    }
     
     /// Configures orientation of preview layer for AVCapture session.
-    private func configureVideoOrientation(for previewLayer: AVCaptureVideoPreviewLayer?) {
+    func configureVideoOrientation(for previewLayer: AVCaptureVideoPreviewLayer?) {
         if let preview = previewLayer,
            let connection = preview.connection {
             let orientation = UIDevice.current.orientation

--- a/Lobe_iOS/Views/PlayView/ImagePicker.swift
+++ b/Lobe_iOS/Views/PlayView/ImagePicker.swift
@@ -21,6 +21,7 @@ struct ImagePicker: UIViewControllerRepresentable {
     
     @Binding var image: UIImage?
     @Binding var viewMode: PlayViewMode
+    let predictionLayer: PredictionLayer
     
     var sourceType: UIImagePickerController.SourceType = .camera
     
@@ -51,6 +52,7 @@ struct ImagePicker: UIViewControllerRepresentable {
 
             if let uiImage = info[UIImagePickerController.InfoKey.originalImage] as? UIImage {
                 self.parent.image = uiImage
+                self.parent.predictionLayer.getPrediction(forImage: uiImage)
                 self.parent.viewMode = .ImagePreview
             }
         }

--- a/Lobe_iOS/Views/PlayView/PlayView.swift
+++ b/Lobe_iOS/Views/PlayView/PlayView.swift
@@ -12,11 +12,6 @@ import SwiftUI
 struct PlayView: View {
     @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
     @ObservedObject var viewModel: PlayViewModel
-    @State var imageForPreview: UIImage?
-    
-    // TO-DO: remove this, only debugging
-    @State var imageForProcessing: UIImage?
-
     
     init(viewModel: PlayViewModel) {
         self.viewModel = viewModel
@@ -41,19 +36,11 @@ struct PlayView: View {
                                             }
                                         }
                                 )
-                            
-                            // TO-DO: remove this, only for debugging
-                            if let imageForProcessing = self.viewModel.captureSessionManager.imageForProcessing {
-                                Image(uiImage: imageForProcessing)
-                                    .resizable()
-                                    .scaledToFit()
-                                    .border(Color.blue, width: 8)
-                            }
                         }
 
                     // Placeholder for displaying an image from the photo library.
                     case .ImagePreview:
-                        ImagePreview(image: self.$imageForPreview, viewMode: self.$viewModel.viewMode)
+                        ImagePreview(image: self.$viewModel.imageFromPhotoPicker, viewMode: self.$viewModel.viewMode)
                         
                     // TO-DO: loading screen here
                     case .NotLoaded:
@@ -64,6 +51,14 @@ struct PlayView: View {
             .edgesIgnoringSafeArea(.all)
 
             VStack {
+                /// Uncomment the below for debugging purposes.
+//                if let imageForProcessing = self.viewModel.imagePredicter.imageForPrediction {
+//                    Image(uiImage: imageForProcessing)
+//                        .resizable()
+//                        .scaledToFit()
+//                        .frame(width: 300, height: 300)
+//                        .border(Color.blue, width: 8)
+//                }
                 Spacer()
                 PredictionLabelView(classificationLabel: self.$viewModel.classificationLabel, confidence: self.$viewModel.confidence, projectName: self.viewModel.project.name)
             }
@@ -83,7 +78,7 @@ struct PlayView: View {
                                 .buttonStyle(PlayViewButtonStyle())
         )
         .sheet(isPresented: self.$viewModel.showImagePicker) {
-            ImagePicker(image: self.$imageForPreview, viewMode: self.$viewModel.viewMode, predictionLayer: self.viewModel.imagePredicter, sourceType: .photoLibrary)
+            ImagePicker(image: self.$viewModel.imageFromPhotoPicker, viewMode: self.$viewModel.viewMode, predictionLayer: self.viewModel.imagePredicter, sourceType: .photoLibrary)
                 .edgesIgnoringSafeArea(.all)
         }
         .onAppear {

--- a/Lobe_iOS/Views/PlayView/PlayView.swift
+++ b/Lobe_iOS/Views/PlayView/PlayView.swift
@@ -52,14 +52,17 @@ struct PlayView: View {
             .edgesIgnoringSafeArea(.all)
 
             VStack {
-                /// Uncomment the below for debugging purposes.
-//                if let imageForProcessing = self.viewModel.imagePredicter.imageForPrediction {
-//                    Image(uiImage: imageForProcessing)
-//                        .resizable()
-//                        .scaledToFit()
-//                        .frame(width: 300, height: 300)
-//                        .border(Color.blue, width: 8)
-//                }
+                /// Show processed image that gets used for prediction.
+                /// Used for debugging purposes
+                if Bool(ProcessInfo.processInfo.environment["SHOW_FORMATTED_IMAGE"] ?? "false") ?? false {
+                    if let imageForProcessing = self.viewModel.imagePredicter.imageForPrediction {
+                        Image(uiImage: imageForProcessing)
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 300, height: 300)
+                            .border(Color.blue, width: 8)
+                    }
+                }
                 Spacer()
                 PredictionLabelView(classificationLabel: self.$viewModel.classificationLabel, confidence: self.$viewModel.confidence, projectName: self.viewModel.project.name)
             }

--- a/Lobe_iOS/Views/PlayView/PlayView.swift
+++ b/Lobe_iOS/Views/PlayView/PlayView.swift
@@ -71,9 +71,12 @@ struct PlayView: View {
         .navigationBarBackButtonHidden(true)
         .navigationBarItems(leading: openScreenButton, trailing:
             HStack {
+                /// Render `rotateCameraButton` for all modes--this is a workaround for bug where right padding is off for `ImagePreview` mode.
+                rotateCameraButton
+                    .disabled(self.viewModel.viewMode != .Camera)
+                    .opacity(self.viewModel.viewMode == .Camera ? 1 : 0)
                 /// Photo picker button if in camera mode, else we show button to toggle to camera mode
                 if (self.viewModel.viewMode == .Camera) {
-                    rotateCameraButton
                     openPhotoPickerButton
                 } else {
                     showCameraModeButton

--- a/Lobe_iOS/Views/PlayView/PlayView.swift
+++ b/Lobe_iOS/Views/PlayView/PlayView.swift
@@ -42,7 +42,6 @@ struct PlayView: View {
                 }
             }
             .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity)
-            .background(Color.black)
             .edgesIgnoringSafeArea(.all)
 
             VStack {
@@ -52,7 +51,17 @@ struct PlayView: View {
         }
         .statusBar(hidden: true)
         .navigationBarBackButtonHidden(true)
-        .navigationBarItems(leading: openScreenButton, trailing: closeImagePreviewButton)
+        .navigationBarItems(leading: openScreenButton, trailing:
+            HStack {
+                /// Photo picker button if in camera mode, else we show button to toggle to camera mode
+                if (self.viewModel.viewMode == .Camera) {
+                    openPhotoPickerButton                    
+                } else {
+                    showCameraModeButton
+                }
+            }
+                                .buttonStyle(PlayViewButtonStyle())
+        )
         .sheet(isPresented: self.$viewModel.showImagePicker) {
             ImagePicker(image: self.$viewModel.image, viewMode: self.$viewModel.viewMode, sourceType: .photoLibrary)
                 .edgesIgnoringSafeArea(.all)
@@ -61,68 +70,51 @@ struct PlayView: View {
 }
 
 extension PlayView {
+    /// Button style for navigation row
+    struct PlayViewButtonStyle: ButtonStyle {
+        func makeBody(configuration: Configuration) -> some View {
+            configuration.label
+                .padding(10)
+                .foregroundColor(.white)
+                .background(Color.black.opacity(0.35).blur(radius: 20))
+                .cornerRadius(8)
+        }
+    }
+
     /// Button for return back to open screen
     var openScreenButton: some View {
         Button(action: {
             self.presentationMode.wrappedValue.dismiss()
         }) {
-            Image(systemName: "square.fill.on.square.fill")
-                .scaleEffect(1.5)
-                .padding()
+            HStack {
+                Image(systemName: "chevron.left")
+                Text("Projects")
+            }
+        }
+        .buttonStyle(PlayViewButtonStyle())
+    }
+    
+    /// Button for opening photo picker
+    var openPhotoPickerButton: some View {
+        Button(action: {
+            self.viewModel.showImagePicker.toggle()
+        }) {
+            Image(systemName: "photo.fill")
         }
     }
     
-    var closeImagePreviewButton: some View {
+    /// Button for enabling camera mode
+    var showCameraModeButton: some View {
         let isVisible = self.viewModel.viewMode == .ImagePreview
         
         return (
             Button(action: { self.viewModel.viewMode = .Camera }) {
-                Image(systemName: "xmark")
-                    .scaleEffect(1.5)
-                    .padding()
+                Image(systemName: "camera.viewfinder")
             }
             .opacity(isVisible ? 1 : 0)
             .disabled(!isVisible)
         )
     }
-    
-    
-    // TO-DO: get below buttons to work again
-    //                HStack {
-    //
-    //                    /* Button for openning the photo library. */
-    //                    Button(action: {
-    //                        withAnimation {
-    //                            self.showImagePicker = true
-    //                        }
-    //                        viewModel.changeStatus(useCam: false, img: self.controller.camImage!)
-    //                    }) {
-    //                        Image("PhotoLib")
-    //                            .renderingMode(.original)
-    //                            .frame(width: geometry.size.width / 3, height: geometry.size.height / 16)
-    //                    }.opacity(0)  // not displaying the button
-    //
-    //                    /* button for taking screenshot. */
-    //                    Button(action: {
-    //                        self.controller.takeScreenShot()
-    //                    }) {
-    //                        Image("Button")
-    //                            .renderingMode(.original)
-    //                            .frame(width: geometry.size.width / 3, height: geometry.size.width / 9)
-    //                    }.opacity(0)  // not displaying the button
-    //
-    //                    /* button for flipping the camera. */
-    //                    Button(action: {
-    //                        self.controller.flipCamera()
-    //                    }) {
-    //                        Image("Swap")
-    //                            .renderingMode(.original)
-    //                            .frame(width: geometry.size.width / 3, height: geometry.size.height / 16)
-    //                    }.opacity(0)  // not displaying the button
-    //                }
-    //                .frame(width: geometry.size.width,
-    //                      height: geometry.size.height / 30, alignment: .bottom)
-    //                .opacity(self.image == nil ? 1: 0)  // hide the buttons when displaying an image from the photo library
 }
 
 /// Gadget to build colors from Hashtag Color Code Hex.
@@ -146,12 +138,31 @@ extension UIColor {
 }
 
 struct PlayView_Previews: PreviewProvider {
+    struct TestImage: View {
+        var body: some View {
+            Image("testing_image")
+                .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity)
+                .edgesIgnoringSafeArea(.all)
+        }
+    }
+    
     static var previews: some View {
         let viewModel = PlayViewModel(project: Project(name: "Test", model: nil))
+        viewModel.viewMode = .Camera
+
         return Group {
-            PlayView(viewModel: viewModel)
-            PlayView(viewModel: viewModel)
-                .previewDevice("iPad Pro (11-inch) (2nd generation)")
+            NavigationView {
+                ZStack {
+                    TestImage()
+                    PlayView(viewModel: viewModel)
+                }
+            }
+            .previewDevice("iPhone 12")
+            ZStack {
+                TestImage()
+                PlayView(viewModel: viewModel)
+            }
+            .previewDevice("iPad Pro (11-inch) (2nd generation)")
         }
     }
 }

--- a/Lobe_iOS/Views/PlayView/PlayView.swift
+++ b/Lobe_iOS/Views/PlayView/PlayView.swift
@@ -13,6 +13,7 @@ struct PlayView: View {
     @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
     @ObservedObject var viewModel: PlayViewModel
     
+    // TO-DO: move this out of playview
     @ObservedObject var captureSessionViewModel: CaptureSessionViewModel
     
     init(viewModel: PlayViewModel) {
@@ -26,7 +27,7 @@ struct PlayView: View {
                 switch(self.viewModel.viewMode) {
                     // Background camera view.
                     case .Camera:
-                        CameraView(captureSessionViewModel: captureSessionViewModel)
+                        CameraView(viewModel: captureSessionViewModel, imageForInference: $viewModel.image)
                         // Gesture for swiping up the photo library.
                         .gesture(
                             DragGesture()

--- a/Lobe_iOS/Views/PlayView/PlayView.swift
+++ b/Lobe_iOS/Views/PlayView/PlayView.swift
@@ -48,6 +48,7 @@ struct PlayView: View {
                 }
             }
             .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity)
+            .background(Color.black)
             .edgesIgnoringSafeArea(.all)
 
             VStack {

--- a/Lobe_iOS/Views/PlayView/PlayView.swift
+++ b/Lobe_iOS/Views/PlayView/PlayView.swift
@@ -43,7 +43,7 @@ struct PlayView: View {
                                 )
                             
                             // TO-DO: remove this, only for debugging
-                            if let imageForProcessing = self.viewModel.imagePredicter.imageForProcessing {
+                            if let imageForProcessing = self.viewModel.captureSessionManager.imageForProcessing {
                                 Image(uiImage: imageForProcessing)
                                     .resizable()
                                     .scaledToFit()


### PR DESCRIPTION
This PR does 2 things:
* Mainly, a substantial refactor of the original view controller, which is decoupled from AV capture session responsibilities.
* Improvements in UI controls

Because:
It's very difficult to interface AV capture logic from the SwiftUI layer if handled in UIKit (aka, our view controller). The workaround would involve very complicated delegation. Now, our view model manages AV capture logic—it's simpler to understand, easier to control, and easier to test.

This commit:

* Refactors
  * Moved AV capture logic out of view controller and into `CaptureSessionManager` in the model layer
    * View controller reduced to setting view layer and handling rotation changes
  * Updated view model for Play view to manage changes for capture session including front/back cam toggling
* UI changes
  * Added buttons for camera rotate and toggle between camera and image preview mode
  * Created new style for buttons which closely mimics desktop design
* Created a debugging mode which displays the image used for inference, and can be toggled by editing environment variable in schemes

## UI

### Camera View
<image src="https://user-images.githubusercontent.com/4683017/103740801-05755480-4f9c-11eb-8a6c-2f33fffd6d30.jpg"  width="400px"/>

### Image Preview
<img src="https://user-images.githubusercontent.com/4683017/103743506-5e46ec00-4fa0-11eb-98b7-cdb710803961.jpeg" width="400px" />

## What's Next

Adding tests for Play view model.

Tagging #17 